### PR TITLE
Fix typo

### DIFF
--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -150,7 +150,7 @@ module.exports = (robot) ->
         task: 'deploy',
         environment: target,
         payload: {user: username, room: room}
-        description: "#{username} deployedzzz #{ref} to #{target}"
+        description: "#{username} deployed #{ref} to #{target}"
       }
 
       github.deployments(app).create ref, options, (deployment) ->


### PR DESCRIPTION
Ah geez, I'm really sorry for this. I wanted to spruce up the messages, so I added `zzz` to the string to see why the test wasn't failing. I realized then that the tests were using a mocked response for `description` -- but I forgot to take this string out! My many apologies.