### PR TITLE
[Feature] add required context to hubot environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Then add **hubot-github-deployments** to your `external-scripts.json`:
 | `HUBOT_GITHUB_USER`           | Yes       | GitHub bot user for deployments (IRC user will be noted in deployment description) |
 | `HUBOT_GITHUB_DEPLOY_TARGETS` | Yes       | Comma-separated list of environments, e.g. `production,staging` |
 | `HUBOT_GITHUB_DEPLOY_AUTO_MERGE` | No       | Passes auto_merge parameter to the deployment `true/false` |
+| `HUBOT_GITHUB_DEPLOY_REQUIRED_CONTEXTS` | No       | Passes required_contexts parameter to the deployment `[]` |
 | `HUBOT_GITHUB_REPO`           | No        | Repository to deploy, in `:owner/:repository format` |
 
 ## Commands:

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -153,7 +153,6 @@ module.exports = (robot) ->
         task: 'deploy',
         environment: target,
         payload: {user: username, room: room},
-        required_contexts: [],
         description: "#{username} created deployment for #{app}@#{ref} to #{target}"
       }
 

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -11,7 +11,7 @@
 #   HUBOT_GITHUB_REPO - GitHub repository to use for deployments
 #   HUBOT_GITHUB_DEPLOY_TARGETS - comma separated keys for your deployment environments.
 #   HUBOT_GITHUB_DEPLOY_AUTO_MERGE - (optional) Instructs GitHub to attempt to automatically merge the default branch into the requested ref.
-#
+#   HUBOT_GITHUB_DEPLOY_REQUIRED_CONTEXTS - (optional) Instructs GitHub to attempt to perform a status check. Pass empty array to skip it.
 # Commands:
 #   hubot deploy status [for :owner/:repo] - List the status of most recent deployments
 #   hubot deploy status [id] [for :owner/:repo]  - List the statuses a particular deployment, or an optional specific status
@@ -130,6 +130,7 @@ module.exports = (robot) ->
 
     app = process.env.HUBOT_GITHUB_REPO
     auto_merge = process.env.HUBOT_GITHUB_DEPLOY_AUTO_MERGE
+    required_contexts = process.env.HUBOT_GITHUB_DEPLOY_REQUIRED_CONTEXTS
     ref = res.match[1]
     target = res.match[2]
 
@@ -156,6 +157,8 @@ module.exports = (robot) ->
       }
 
       data['auto_merge'] = auto_merge == 'true' if auto_merge
+
+      data['required_contexts'] = required_contexts if required_contexts
 
       github.deployments(app).create ref, data, (deployment) ->
         res.send deployment.description

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -152,7 +152,8 @@ module.exports = (robot) ->
         ref: ref,
         task: 'deploy',
         environment: target,
-        payload: {user: username, room: room}
+        payload: {user: username, room: room},
+        required_contexts: [],
         description: "#{username} created deployment for #{app}@#{ref} to #{target}"
       }
 


### PR DESCRIPTION
This is a PR to add required contexts parameter to hubot github deployment.

Sometimes. optionally, we don't really need to check all the status on our commit sha. 

With this option, we can add any contexts that is required to deploy our commits to production/staging.

ref: https://docs.github.com/en/rest/reference/deployments 