### PR TITLE
add consistent OWNER env variable

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,9 @@
 name: Node CI
 
-on: [push]
+on: 
+  push:
+    branches:
+      - "**"
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,9 +1,8 @@
 name: Node CI
 
-on: 
+on:
   push:
-    branches:
-      - "**"
+  pull_request:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ Then add **hubot-github-deployments** to your `external-scripts.json`:
 | `HUBOT_GITHUB_DEPLOY_TARGETS` | Yes       | Comma-separated list of environments, e.g. `production,staging` |
 | `HUBOT_GITHUB_DEPLOY_AUTO_MERGE` | No       | Passes auto_merge parameter to the deployment `true/false` |
 | `HUBOT_GITHUB_DEPLOY_REQUIRED_CONTEXTS` | No       | Passes required_contexts parameter to the deployment `[]` |
-| `HUBOT_GITHUB_REPO`           | No        | Repository to deploy, in `:owner/:repository format` |
+| `HUBOT_GITHUB_REPO`           | No        | Repository to deploy, in `:owner/:repository`` format |
+| `HUBOT_GITHUB_OWNER`          | No        | Repository owner for deploy/info `:owner`, let's us shorten `for :owner/:repository` format |
 
 ## Commands:
 
-- `hubot deploy status [for :owner/:repo]` - List the status of most recent deployments
-- `hubot deploy status [id] [for :owner/:repo]` - List the statuses a particular deployment, or an optional specific status
-- `hubot deploy list targets [for :owner/:repo]` - List available deployment targets
-- `hubot deploy list branches [for :owner/:repo] [search]` - List available branches, filtered by optional search term
-- `hubot deploy <branch or SHA> to <server> [for :owner/:repo]` - Creates a Github deployment of a branch/SHA to a server
+- `hubot deploy status [for :owner/:repo|:repo]` - List the status of most recent deployments
+- `hubot deploy status [id] [for :owner/:repo|:repo]` - List the statuses a particular deployment, or an optional specific status
+- `hubot deploy list targets [for :owner/:repo|:repo]` - List available deployment targets
+- `hubot deploy list branches [for :owner/:repo|:repo] [search]` - List available branches, filtered by optional search term
+- `hubot deploy <branch or SHA> to <server> [for :owner/:repo|:repo]` - Creates a Github deployment of a branch/SHA to a server

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "sinon-chai": "^3.7.0"
       },
       "peerDependencies": {
-        "hubot": "^3 || ^4"
+        "hubot": ">=2 <10 || 0.0.0-development"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -114,7 +114,7 @@ module.exports = (robot) ->
     unless checkConfiguration(res)
       return;
 
-    app = getRepoInfo(res.match[3], match[4])
+    app = getRepoInfo(res.match[3], res.match[4])
     if !app?
       res.send "Missing configuration: HUBOT_GITHUB_REPO"
       return false

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -40,6 +40,9 @@ module.exports = (robot) ->
 
     status_id = res.match[1]
     app = getRepoInfo(res.match[2], res.match[3]) 
+    if !app?
+      res.send "Missing configuration: HUBOT_GITHUB_REPO"
+      return false
 
     if status_id?
       status_id = status_id.trim()
@@ -78,6 +81,9 @@ module.exports = (robot) ->
       return;
 
     app = getRepoInfo(res.match[1], res.match[2])
+    if !app?
+      res.send "Missing configuration: HUBOT_GITHUB_REPO"
+      return false
 
     filter = res.match[3].toLowerCase().trim()
 
@@ -109,6 +115,9 @@ module.exports = (robot) ->
       return;
 
     app = getRepoInfo(res.match[3], match[4])
+    if !app?
+      res.send "Missing configuration: HUBOT_GITHUB_REPO"
+      return false
     auto_merge = process.env.HUBOT_GITHUB_DEPLOY_AUTO_MERGE
     required_contexts = process.env.HUBOT_GITHUB_DEPLOY_REQUIRED_CONTEXTS
     ref = res.match[1]
@@ -156,12 +165,11 @@ module.exports = (robot) ->
       owner = match1
     repo = match2
 
-    if !owner? && !repo?
+    if !owner? && !repo? && !app?
       if !app?
-        res.send "Missing configuration: HUBOT_GITHUB_REPO"
-        return false
-    else
-      app = "#{owner}/#{repo}"
+        app = ""
+      else
+        app = "#{owner}/#{repo}"
     return app
 
   # Check Config

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -165,11 +165,10 @@ module.exports = (robot) ->
       owner = match1
     repo = match2
 
-    if !owner? && !repo? && !app?
-      if !app?
-        app = ""
-      else
-        app = "#{owner}/#{repo}"
+    if !owner? && !repo?
+      app = ""
+    else
+      app = "#{owner}/#{repo}"
     return app
 
   # Check Config

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -38,18 +38,8 @@ module.exports = (robot) ->
     unless checkConfiguration(res)
       return;
 
-    app = process.env.HUBOT_GITHUB_REPO
     status_id = res.match[1]
-
-    owner = res.match[2]
-    repo = res.match[3]
-
-    if !owner? && !repo?
-      if !app?
-        res.send "Missing configuration: HUBOT_GITHUB_REPO"
-        return false
-    else
-      app = "#{owner}/#{repo}"
+    app = getRepoInfo(res.match[2], res.match[3]) 
 
     if status_id?
       status_id = status_id.trim()
@@ -87,17 +77,7 @@ module.exports = (robot) ->
     unless checkConfiguration(res)
       return;
 
-
-    app = process.env.HUBOT_GITHUB_REPO
-    owner = res.match[1]
-    repo = res.match[2]
-
-    if !owner? && !repo?
-      if !app?
-        res.send "Missing configuration: HUBOT_GITHUB_REPO"
-        return false
-    else
-      app = "#{owner}/#{repo}"
+    app = getRepoInfo(res.match[1], res.match[2])
 
     filter = res.match[3].toLowerCase().trim()
 
@@ -128,7 +108,7 @@ module.exports = (robot) ->
     unless checkConfiguration(res)
       return;
 
-    app = process.env.HUBOT_GITHUB_REPO
+    app = getRepoInfo(res.match[3], match[4])
     auto_merge = process.env.HUBOT_GITHUB_DEPLOY_AUTO_MERGE
     required_contexts = process.env.HUBOT_GITHUB_DEPLOY_REQUIRED_CONTEXTS
     ref = res.match[1]
@@ -137,16 +117,6 @@ module.exports = (robot) ->
     if target in deployTargets
       username = res.message.user.name.toLowerCase()
       room = res.message.user.room.toLowerCase()
-
-      owner = res.match[3]
-      repo = res.match[4]
-
-      if !owner? && !repo?
-        if !app?
-          res.send "Missing configuration: HUBOT_GITHUB_REPO"
-          return false
-      else
-        app = "#{owner}/#{repo}"
 
       data = {
         ref: ref,
@@ -177,6 +147,22 @@ module.exports = (robot) ->
     unless robot.name.toLowerCase() is 'hubot'
       emit = emit.replace /hubot/ig, robot.name
     res.send emit
+
+  # Get repo settings
+  getRepoInfo = (match1, match2) ->
+    app = process.env.HUBOT_GITHUB_REPO
+    owner = process.env.HUBOT_GITHUB_OWNER
+    if !owner?
+      owner = match1
+    repo = match2
+
+    if !owner? && !repo?
+      if !app?
+        res.send "Missing configuration: HUBOT_GITHUB_REPO"
+        return false
+    else
+      app = "#{owner}/#{repo}"
+    return app
 
   # Check Config
   checkConfiguration = (res) ->

--- a/src/github-deployments.coffee
+++ b/src/github-deployments.coffee
@@ -166,7 +166,8 @@ module.exports = (robot) ->
     repo = match2
 
     if !owner? && !repo?
-      app = ""
+      if !app?
+        app = ""
     else
       app = "#{owner}/#{repo}"
     return app


### PR DESCRIPTION
Idea I had: If a user has many repos in a org, being able to skip writing `for :org/:repo` on every command would be nice. I _think_ this works, although I'm still testing a bit.